### PR TITLE
Guarda no banco de dados o timestamp de quando o token irá vencer

### DIFF
--- a/src/Box.php
+++ b/src/Box.php
@@ -13,6 +13,8 @@ use GuzzleHttp\Psr7\Response;
 
 class Box
 {
+    const ERROR_MARGIN = 100;
+
     const METHOD_GET = 'get';
 
     public function files(): object
@@ -65,7 +67,9 @@ class Box
 
             $token = $this->dopost(config('box.urlAccessToken'), $params);
 
-            $this->storeToken($token->access_token, $token->refresh_token, $token->expires_in);
+            $expires = time() + intval($token->expires_in) - self::ERROR_MARGIN;
+
+            $this->storeToken($token->access_token, $token->refresh_token, $expires);
 
             return $this->redirect(config('box.boxLandingUri'));
         }
@@ -99,8 +103,10 @@ class Box
             ];
             $accessToken = $this->dopost(config('box.urlAccessToken'), $params);
 
+            $expires = time() + intval($accessToken->expires_in) - self::ERROR_MARGIN;
+
             // Store the new values
-            $this->storeToken($accessToken->access_token, $accessToken->refresh_token, $accessToken->expires_in);
+            $this->storeToken($accessToken->access_token, $accessToken->refresh_token, $expires);
 
             return $accessToken->access_token;
         }


### PR DESCRIPTION
Existe um bug em que toda requisição está triggando o refresh token para pegar um novo access token. Isso ocorre porque a checagem da validade está errada.

Pra resolver esse problema rápido e sem necessidade de gerar migrations (para guardar a data de criação do token), estou guardando somente o timestamp em que o token irá vencer. Assim, podemos fazer uma comparação simples de "now" com "data de expiração do token".

Como o box não retorna a data exata de criação do token, estou considerando que seja o "now" do nosso sistema na hora que fazemos a requisição por um novo token. Como isso uma margem para erro, estou diminuindo 100 segundos da expiração, para evitar falsos positivos.